### PR TITLE
Use generators for matching stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 /venv/
 /.idea/
 __pycache__/
+*.egg-info
 
 # "libraries"
 /wiki-news-300d-1M-subword.vec
 /stanford-corenlp-full-2020-04-20
-/glove.6B.300d.txt
+/glove.*.txt
 
 # input and output
 /input/*

--- a/aset/matching/matchingstage.py
+++ b/aset/matching/matchingstage.py
@@ -121,19 +121,11 @@ class MatchingStage(Component):
         elif self.strategy is None:
             logger.error("No strategy has been defined!")
         else:
-            gen = self.strategy(self.documents, self.attributes)
-            add_next = None
-            while True:
-                is_finished, result = gen.send(add_next)
-                if is_finished:
-                    gen.close()
-                    break
-                add_next = yield is_finished, result
+            self.rows = yield from self.strategy(self.documents, self.attributes)
 
         tak = time()
 
         logger.info(f"Matched extractions in {tak - tik} seconds.")
-        yield True, result
 
     @property
     def table_str(self):

--- a/aset/matching/matchingstage.py
+++ b/aset/matching/matchingstage.py
@@ -115,16 +115,25 @@ class MatchingStage(Component):
         tik = time()
 
         # match the extractions to the rows
+        result = None
         if len(self.attributes) == 0:
             logger.error("There are no attributes the extractions could be matched to!")
         elif self.strategy is None:
             logger.error("No strategy has been defined!")
         else:
-            self.rows = self.strategy(self.documents, self.attributes)
+            gen = self.strategy(self.documents, self.attributes)
+            add_next = None
+            while True:
+                is_finished, result = gen.send(add_next)
+                if is_finished:
+                    gen.close()
+                    break
+                add_next = yield is_finished, result
 
         tak = time()
 
         logger.info(f"Matched extractions in {tak - tik} seconds.")
+        yield True, result
 
     @property
     def table_str(self):

--- a/aset/matching/strategies.py
+++ b/aset/matching/strategies.py
@@ -124,8 +124,7 @@ class TreeSearchExploration(BaseStrategy):
 
                 document, extraction, distance = choices(remaining, weights=softmax_weights)[0]
                 num_interactions += 1
-                # if self.query_user_fn(document, attribute, extraction, num_interactions):
-                is_add_attribute = yield False, (document, attribute, extraction, num_interactions)
+                is_add_attribute = yield document, attribute, extraction, num_interactions
                 if is_add_attribute:
                     matching_extractions.append((document, extraction))
                     new_remaining = []
@@ -187,8 +186,7 @@ class TreeSearchExploration(BaseStrategy):
                 for doc, ext, dist in samples:
                     if num_interactions < self.max_interactions:
                         num_interactions += 1
-                        # if self.query_user_fn(doc, attribute, ext, num_interactions):
-                        is_add_attribute = yield False, (doc, attribute, ext, num_interactions)
+                        is_add_attribute = yield doc, attribute, ext, num_interactions
                         if is_add_attribute:
                             matching_extractions.append((doc, ext))
                             new_matching.append((doc, ext, dist))
@@ -225,7 +223,7 @@ class TreeSearchExploration(BaseStrategy):
                     rows[document].extractions[attribute.label] = extraction
                     closest_distances[document] = distance
 
-        return True, rows
+        return rows
 
 
 class DFSExploration(BaseStrategy):
@@ -288,8 +286,7 @@ class DFSExploration(BaseStrategy):
                     document_index, extraction, distance = choices(remaining, weights=softmax_weights)[0]
 
                     num_interactions += 1
-                    is_add_attribute = yield False(document_index, attribute, extraction, num_interactions)
-                    # if self.query_user_fn(document_index, attribute, extraction, num_interactions):
+                    is_add_attribute = yield document_index, attribute, extraction, num_interactions
                     if is_add_attribute:
                         remaining = list(filter(lambda x: x[0] != document_index, remaining))
                         matching_extractions.append((document_index, extraction))
@@ -337,8 +334,7 @@ class DFSExploration(BaseStrategy):
                     for doc, ext, dist in samples:
                         if num_interactions < self.max_interactions:
                             num_interactions += 1
-                            # if self.query_user_fn(doc, attribute, ext, num_interactions):
-                            is_add_attribute = yield False, (doc, attribute, ext, num_interactions)
+                            is_add_attribute = yield doc, attribute, ext, num_interactions
                             if is_add_attribute:
                                 matching_extractions.append((doc, ext))
                                 new_matching.append((doc, ext))
@@ -371,7 +367,7 @@ class DFSExploration(BaseStrategy):
                     rows[document_index].extractions[attribute.label] = extraction
                     closest_distances[document_index] = distance
 
-        yield True, rows
+        return rows
 
 
 def query_user(document_index: int, attribute: Attribute, extraction: Extraction, num_interactions: int):

--- a/aset/matching/strategies.py
+++ b/aset/matching/strategies.py
@@ -128,7 +128,9 @@ class TreeSearchExploration(BaseStrategy):
                 num_interactions += 1
                 if not skip:
                     is_add_attribute, skip = yield document, attribute, extraction, num_interactions
-                if skip or is_add_attribute:
+                if skip:
+                    break
+                if is_add_attribute:
                     matching_extractions.append((document, extraction))
                     new_remaining = []
                     new_weights = []
@@ -191,7 +193,9 @@ class TreeSearchExploration(BaseStrategy):
                         num_interactions += 1
                         if not skip:
                             is_add_attribute, skip = yield doc, attribute, ext, num_interactions
-                        if skip or is_add_attribute:
+                        if skip:
+                            break
+                        if is_add_attribute:
                             matching_extractions.append((doc, ext))
                             new_matching.append((doc, ext, dist))
 
@@ -293,7 +297,9 @@ class DFSExploration(BaseStrategy):
                     num_interactions += 1
                     if not skip:
                         is_add_attribute, skip = yield document_index, attribute, extraction, num_interactions
-                    if skip or is_add_attribute:
+                    if skip:
+                        break
+                    if is_add_attribute:
                         remaining = list(filter(lambda x: x[0] != document_index, remaining))
                         matching_extractions.append((document_index, extraction))
                         queue.append((document_index, extraction))
@@ -342,7 +348,9 @@ class DFSExploration(BaseStrategy):
                             num_interactions += 1
                             if not skip:
                                 is_add_attribute, skip = yield doc, attribute, ext, num_interactions
-                            if skip or is_add_attribute:
+                            if skip:
+                                break
+                            if is_add_attribute:
                                 matching_extractions.append((doc, ext))
                                 new_matching.append((doc, ext))
 

--- a/aset/matching/strategies.py
+++ b/aset/matching/strategies.py
@@ -58,6 +58,7 @@ class StaticMatching(BaseStrategy):
                         closest_dist = dist
 
         return rows
+        yield # this will never be called, but it makes this function return a generator
 
 
 class TreeSearchExploration(BaseStrategy):

--- a/aset/matching/strategies.py
+++ b/aset/matching/strategies.py
@@ -117,6 +117,7 @@ class TreeSearchExploration(BaseStrategy):
                     weights.append(1 - distance)
 
             # sample extractions with rising temperature and present them to the user
+            skip = False
             while len(matching_extractions) < self.max_roots \
                     and (matching_extractions == [] or num_interactions < self.max_initial_tries) \
                     and num_interactions < self.max_interactions:
@@ -125,8 +126,9 @@ class TreeSearchExploration(BaseStrategy):
 
                 document, extraction, distance = choices(remaining, weights=softmax_weights)[0]
                 num_interactions += 1
-                is_add_attribute = yield document, attribute, extraction, num_interactions
-                if is_add_attribute:
+                if not skip:
+                    is_add_attribute, skip = yield document, attribute, extraction, num_interactions
+                if skip or is_add_attribute:
                     matching_extractions.append((document, extraction))
                     new_remaining = []
                     new_weights = []
@@ -187,8 +189,9 @@ class TreeSearchExploration(BaseStrategy):
                 for doc, ext, dist in samples:
                     if num_interactions < self.max_interactions:
                         num_interactions += 1
-                        is_add_attribute = yield doc, attribute, ext, num_interactions
-                        if is_add_attribute:
+                        if not skip:
+                            is_add_attribute, skip = yield doc, attribute, ext, num_interactions
+                        if skip or is_add_attribute:
                             matching_extractions.append((doc, ext))
                             new_matching.append((doc, ext, dist))
 
@@ -275,6 +278,7 @@ class DFSExploration(BaseStrategy):
                     distance = attribute.embedding.distance(extraction.embedding)
                     remaining.append((document_index, extraction, distance))
 
+            skip = False
             while num_interactions < self.max_interactions:
 
                 # find a root
@@ -287,8 +291,9 @@ class DFSExploration(BaseStrategy):
                     document_index, extraction, distance = choices(remaining, weights=softmax_weights)[0]
 
                     num_interactions += 1
-                    is_add_attribute = yield document_index, attribute, extraction, num_interactions
-                    if is_add_attribute:
+                    if not skip:
+                        is_add_attribute, skip = yield document_index, attribute, extraction, num_interactions
+                    if skip or is_add_attribute:
                         remaining = list(filter(lambda x: x[0] != document_index, remaining))
                         matching_extractions.append((document_index, extraction))
                         queue.append((document_index, extraction))
@@ -335,8 +340,9 @@ class DFSExploration(BaseStrategy):
                     for doc, ext, dist in samples:
                         if num_interactions < self.max_interactions:
                             num_interactions += 1
-                            is_add_attribute = yield doc, attribute, ext, num_interactions
-                            if is_add_attribute:
+                            if not skip:
+                                is_add_attribute, skip = yield doc, attribute, ext, num_interactions
+                            if skip or is_add_attribute:
                                 matching_extractions.append((doc, ext))
                                 new_matching.append((doc, ext))
 

--- a/aset_ui/onlinephase.py
+++ b/aset_ui/onlinephase.py
@@ -540,11 +540,16 @@ class OnlinePhaseWorker(QObject):
                 self.mutex.unlock()
             return self.value
 
-        strategies.query_user = query_user
-
         # noinspection PyUnresolvedReferences
         self.matching_preparation_finished_to_ui.emit()
-        self.matching_stage.match_extractions_to_attributes()
+        generator = self.matching_stage.match_extractions_to_attributes()
+        document, attribute, extraction, num_interactions = next(generator)
+        while True:
+            try:
+                is_match = query_user(document, attribute, extraction, num_interactions)
+                document, attribute, extraction, num_interactions = generator.send(is_match)
+            except StopIteration:
+                break
 
         # noinspection PyUnresolvedReferences
         self.next_to_ui.emit()

--- a/aset_ui/onlinephase.py
+++ b/aset_ui/onlinephase.py
@@ -547,7 +547,7 @@ class OnlinePhaseWorker(QObject):
         while True:
             try:
                 is_match = query_user(document, attribute, extraction, num_interactions)
-                document, attribute, extraction, num_interactions = generator.send(is_match)
+                document, attribute, extraction, num_interactions = generator.send((is_match, False))
             except StopIteration:
                 break
 

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
         while True:
             try:
                 is_match = query_user(document, attribute, extraction, num_interactions)
-                document, attribute, extraction, num_interactions = generator.send(is_match)
+                document, attribute, extraction, num_interactions = generator.send((is_match, False))
             except StopIteration:
                 break
 

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from aset.extraction.processors import StanfordCoreNLPDateTimeProcessor, Stanfor
     StanfordCoreNLPStringProcessor
 from aset.matching.common import Attribute
 from aset.matching.matchingstage import MatchingStage
-from aset.matching.strategies import TreeSearchExploration
+from aset.matching.strategies import TreeSearchExploration, query_user
 
 logging.config.fileConfig("logging.conf", disable_existing_loggers=False)
 logger = logging.getLogger()
@@ -101,7 +101,14 @@ if __name__ == "__main__":
         )
         matching_stage.compute_attribute_embeddings()
         matching_stage.incorporate_example_mentions(example_mentions)
-        matching_stage.match_extractions_to_attributes()
+        generator = matching_stage.match_extractions_to_attributes()
+        document, attribute, extraction, num_interactions = next(generator)
+        while True:
+            try:
+                is_match = query_user(document, attribute, extraction, num_interactions)
+                document, attribute, extraction, num_interactions = generator.send(is_match)
+            except StopIteration:
+                break
 
         # display the results
         print("\n\n\n")

--- a/paper_experiments/exp2_run.py
+++ b/paper_experiments/exp2_run.py
@@ -114,7 +114,7 @@ def do_evaluation_run(
     while True:
         try:
             is_match = automatic_query_user(document, attribute, extraction, num_interactions)
-            document, attribute, extraction, num_interactions = generator.send(is_match)
+            document, attribute, extraction, num_interactions = generator.send((is_match, False))
         except StopIteration:
             break
 

--- a/paper_experiments/exp2_run.py
+++ b/paper_experiments/exp2_run.py
@@ -109,8 +109,14 @@ def do_evaluation_run(
 
         return match
 
-    strategies.query_user = automatic_query_user
-    aset_matching_stage.match_extractions_to_attributes()
+    generator = aset_matching_stage.match_extractions_to_attributes()
+    document, attribute, extraction, num_interactions = next(generator)
+    while True:
+        try:
+            is_match = automatic_query_user(document, attribute, extraction, num_interactions)
+            document, attribute, extraction, num_interactions = generator.send(is_match)
+        except StopIteration:
+            break
 
     # evaluate the matching process
     recalls = {}

--- a/paper_experiments/exp3_run.py
+++ b/paper_experiments/exp3_run.py
@@ -123,7 +123,7 @@ def do_evaluation_run(
     while True:
         try:
             is_match = automatic_query_user(document, attribute, extraction, num_interactions)
-            document, attribute, extraction, num_interactions = generator.send(is_match)
+            document, attribute, extraction, num_interactions = generator.send((is_match, False))
         except StopIteration:
             break
 

--- a/paper_experiments/exp3_run.py
+++ b/paper_experiments/exp3_run.py
@@ -118,8 +118,14 @@ def do_evaluation_run(
 
         return match
 
-    strategies.query_user = automatic_query_user
-    aset_matching_stage.match_extractions_to_attributes()
+    generator = aset_matching_stage.match_extractions_to_attributes()
+    document, attribute, extraction, num_interactions = next(generator)
+    while True:
+        try:
+            is_match = automatic_query_user(document, attribute, extraction, num_interactions)
+            document, attribute, extraction, num_interactions = generator.send(is_match)
+        except StopIteration:
+            break
 
     # evaluate the matching process
     recalls = {}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+
+setup(
+    name="aset",
+    version="0.0",
+    py_modules=["aset"],
+    install_requires=[
+        "torch==1.8.0",
+        "numpy==1.19.0",
+        "pandas==1.2.3",
+        "scipy==1.6.1",
+        "matplotlib==3.3.4",
+        "transformers==4.3.3",
+        "sentence-transformers==0.4.1.2",
+        "stanza==1.2",
+    ],
+)


### PR DESCRIPTION
The matching stage now uses generators, which was necessary to allow querying the user for matches in the I-ASET frontend properly.